### PR TITLE
Add link to MAESTRO Threat Modeling Playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This tool is based on the **MAESTRO** framework for agentic AI threat modeling, 
 
 We highly recommend reading the paper to understand the seven-layer architecture and the principles behind this tool.
 
+### Related Resources
+
+- **Playbook**: [OWASP MAESTRO Threat Modeling Playbook](https://github.com/agentic-threat-modeling/MAESTRO) - A structured methodology companion with checklists, threat taxonomy IDs, mitigation catalogs, scoring, templates, and worked examples. Based on the [OWASP MAS Threat Modelling Guide v1.0](https://genai.owasp.org/resource/multi-agentic-system-threat-modeling-guide-v1-0/).
+
 ## Features
 
 - **Detailed Architecture Input**: Provides a textarea for users to describe their system architecture, which is used by the AI for analysis.


### PR DESCRIPTION
Hey, we built a detailed playbook for the MAESTRO framework that pairs well with this app. Your tool handles interactive threat analysis, ours covers the methodology side: checklists, threat taxonomy with IDs, mitigation catalogs, scoring, templates, worked examples.

Repo: https://github.com/agentic-threat-modeling/MAESTRO

Based on the same [OWASP MAS Threat Modelling Guide v1.0](https://genai.owasp.org/resource/multi-agentic-system-threat-modeling-guide-v1-0/), CC BY-SA 4.0.

**A few things we noticed in the code:**

- Threat analysis prompt has 5 agentic factors but the OWASP source defines 4
- No cross-layer analysis (the guide defines 7 cross-layer patterns)
- Threat output doesn't reference ASI taxonomy IDs (T1-T15)

Happy to contribute fixes, add a link in the README, or include the playbook as docs. Whatever works.